### PR TITLE
Asset path fix

### DIFF
--- a/opensuse/13.2/Dockerfile
+++ b/opensuse/13.2/Dockerfile
@@ -128,8 +128,8 @@ RUN bash -c "echo -e '\n# activate default Anaconda environment' >> ~/.bashrc" &
 #_______________________________________________________________________________
 # Add an entrypoint script and an Anaconda global config file:
 
-COPY assets/entrypoint.sh /sbin
-COPY assets/.condarc /opt/conda
+COPY ../../assets/entrypoint.sh /sbin
+COPY ../../assets/.condarc /opt/conda
 
 
 #_______________________________________________________________________________

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -138,8 +138,8 @@ RUN bash -c "echo -e '\n# activate default Anaconda environment' >> ~/.bashrc" &
 #_______________________________________________________________________________
 # Add an entrypoint script and an Anaconda global config file:
 
-COPY assets/entrypoint.sh /sbin
-COPY assets/.condarc /opt/conda
+COPY ../../assets/entrypoint.sh /sbin
+COPY ../../assets/.condarc /opt/conda
 
 
 #_______________________________________________________________________________


### PR DESCRIPTION
Builds on Docker Hub fail because the builder can't find the `assets` directory. I assume that the Docker system switches into the directory of the Dockerfile first, so I added the relative path to the  `assets`.

Let's see if that works...
